### PR TITLE
Support for changing the light colors

### DIFF
--- a/StreamDeckTradfri/Actions/SetLightAction.cs
+++ b/StreamDeckTradfri/Actions/SetLightAction.cs
@@ -12,8 +12,9 @@ namespace StreamDeckTradfri.Actions
     [ActionUuid(Uuid = "no.heinandre.tradfri.action.set-light")]
     public class SetLightAction : BaseStreamDeckActionWithSettingsModel<Models.SetLightActionSettings>
     {
-        public Dictionary<string, string> TradfriColors = new Dictionary<string, string>()
+        public Dictionary<string, string> TradfriColors = new()
         {
+            { "None", "" },
             { "Blue", "4a418a" },
             { "LightBlue", "6c83ba" },
             { "SaturatedPurple", "8f2686" },

--- a/StreamDeckTradfri/Actions/SetLightAction.cs
+++ b/StreamDeckTradfri/Actions/SetLightAction.cs
@@ -1,6 +1,8 @@
 ﻿using StreamDeckLib;
 using StreamDeckLib.Messages;
 using StreamDeckTradfri.Tradfri;
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Tomidix.NetStandard.Tradfri.Models;
@@ -10,6 +12,30 @@ namespace StreamDeckTradfri.Actions
     [ActionUuid(Uuid = "no.heinandre.tradfri.action.set-light")]
     public class SetLightAction : BaseStreamDeckActionWithSettingsModel<Models.SetLightActionSettings>
     {
+        public Dictionary<string, string> TradfriColors = new Dictionary<string, string>()
+        {
+            { "Blue", "4a418a" },
+            { "LightBlue", "6c83ba" },
+            { "SaturatedPurple", "8f2686" },
+            { "Lime", "a9d62b" },
+            { "LightPurple", "c984bb" },
+            { "Yellow", "d6e44b" },
+            { "SaturatedPink", "d9337c" },
+            { "DarkPeach", "da5d41" },
+            { "SaturatedRed", "dc4b31" },
+            { "ColdSky", "dcf0f8" },
+            { "Pink", "e491af" },
+            { "Peach", "e57345" },
+            { "WarmAmber", "e78834" },
+            { "LightPink", "e8bedd" },
+            { "CoolDaylight", "eaf6fb" },
+            { "CandleLight", "ebb63e" },
+            { "WarmGlow", "efd275" },
+            { "WarmWhite", "f1e0b5" },
+            { "Sunrise", "f2eccf" },
+            { "CoolWhite", "f5faf6 "}
+        };
+
         public override Task OnApplicationDidLaunchAsync(StreamDeckEventPayload args)
         {
             return base.OnApplicationDidLaunchAsync(args);
@@ -30,7 +56,7 @@ namespace StreamDeckTradfri.Actions
             {
                 foreach (var device in devices)
                 {
-                    SetLight(device, SettingsModel.Dimmer);
+                    SetLight(device, SettingsModel.Dimmer, TradfriColors[SettingsModel.Color]);
                 }
             }
         }

--- a/StreamDeckTradfri/Models/SetLightActionSettings.cs
+++ b/StreamDeckTradfri/Models/SetLightActionSettings.cs
@@ -4,7 +4,7 @@
   {
         public string Light { get; set; } = "";
         public int Dimmer { get; set; } = 0;
-        public string Color { get; set; } = "4a418a";
+        public string Color { get; set; } = "";
 
 	}
 }

--- a/StreamDeckTradfri/Models/SetLightActionSettings.cs
+++ b/StreamDeckTradfri/Models/SetLightActionSettings.cs
@@ -4,5 +4,7 @@
   {
         public string Light { get; set; } = "";
         public int Dimmer { get; set; } = 0;
-    }
+        public string Color { get; set; } = "4a418a";
+
+	}
 }

--- a/StreamDeckTradfri/PropertyInspector/js/property-inspector-light.js
+++ b/StreamDeckTradfri/PropertyInspector/js/property-inspector-light.js
@@ -48,7 +48,7 @@ function connectElgatoStreamDeckSocket(inPort, inUUID, inRegisterEvent, inInfo, 
                     settingsModel.Dimmer = jsonObj.payload.settings.settingsModel.Dimmer;
                     document.getElementById('txtDimmer').value = settingsModel.Dimmer;
 
-                    ettingsModel.Color = jsonObj.payload.settings.settingsModel.Color;
+                    settingsModel.Color = jsonObj.payload.settings.settingsModel.Color;
                     document.getElementById('txtColor').value = settingsModel.Color;
                 }
                 break;

--- a/StreamDeckTradfri/PropertyInspector/js/property-inspector-light.js
+++ b/StreamDeckTradfri/PropertyInspector/js/property-inspector-light.js
@@ -6,7 +6,8 @@ var websocket = null,
     actionInfo = {},
     settingsModel = {
         Light: "",
-        Dimmer: 0
+        Dimmer: 0,
+        Color: "ffffff"
     };
 
 function connectElgatoStreamDeckSocket(inPort, inUUID, inRegisterEvent, inInfo, inActionInfo) {
@@ -19,10 +20,12 @@ function connectElgatoStreamDeckSocket(inPort, inUUID, inRegisterEvent, inInfo, 
     if (actionInfo.payload.settings.settingsModel) {
         settingsModel.Light = actionInfo.payload.settings.settingsModel.Light;
         settingsModel.Dimmer = actionInfo.payload.settings.settingsModel.Dimmer;
+        settingsModel.Color = actionInfo.payload.settings.settingsModel.Color;
     }
 
     document.getElementById('txtLight').value = settingsModel.Light;
     document.getElementById('txtDimmer').value = settingsModel.Dimmer;
+    document.getElementById('txtColor').value = settingsModel.Color;
 
     websocket.onopen = function () {
         var json = { event: inRegisterEvent, uuid: inUUID };
@@ -44,6 +47,9 @@ function connectElgatoStreamDeckSocket(inPort, inUUID, inRegisterEvent, inInfo, 
 
                     settingsModel.Dimmer = jsonObj.payload.settings.settingsModel.Dimmer;
                     document.getElementById('txtDimmer').value = settingsModel.Dimmer;
+
+                    ettingsModel.Color = jsonObj.payload.settings.settingsModel.Color;
+                    document.getElementById('txtColor').value = settingsModel.Color;
                 }
                 break;
             default:

--- a/StreamDeckTradfri/PropertyInspector/property_inspector_light.html
+++ b/StreamDeckTradfri/PropertyInspector/property_inspector_light.html
@@ -24,6 +24,32 @@
             <input id="txtDimmer" class="sdpi-item-value" type="text" max="100" min="0" onchange="setSettings(event.target.value, 'Dimmer')" />
         </div>
 
+        <div class="sdpi-item">
+            <div class="sdpi-item-label">Color</div>
+            <select id="txtColor" class="sdpi-item-value" type="text" onchange="setSettings(event.target.value, 'Color')">                
+                <option value="Blue">Blue</option> 
+                <option value="LightBlue">Light Blue</option> 
+                <option value="SaturatedPurple">Saturated Purple</option> 
+                <option value="Lime">Lime</option> 
+                <option value="LightPurple">Light Purple</option> 
+                <option value="Yellow">Yellow</option> 
+                <option value="SaturatedPink">Saturated Pink</option> 
+                <option value="DarkPeach">Dark Peach</option> 
+                <option value="SaturatedRed">Saturated Red</option> 
+                <option value="ColdSky">Cold Sky</option> 
+                <option value="Pink">Pink</option> 
+                <option value="Peach">Peach</option> 
+                <option value="WarmAmber">Warm Amber</option> 
+                <option value="LightPink">Light Pink</option> 
+                <option value="CoolDaylight">Cool Daylight</option> 
+                <option value="CandleLight">Candlelight</option> 
+                <option value="WarmGlow">Warm Glow</option> 
+                <option value="WarmWhite">Warm White</option> 
+                <option value="Sunrise">Sunrise</option> 
+                <option value="CoolWhite">Cool White</option> 
+            </select>
+        </div>
+
     </div>
     <script src="js/property-inspector-light.js"></script>
 </body>

--- a/StreamDeckTradfri/PropertyInspector/property_inspector_light.html
+++ b/StreamDeckTradfri/PropertyInspector/property_inspector_light.html
@@ -27,6 +27,7 @@
         <div class="sdpi-item">
             <div class="sdpi-item-label">Color</div>
             <select id="txtColor" class="sdpi-item-value" type="text" onchange="setSettings(event.target.value, 'Color')">                
+                <option value="None">None</option> 
                 <option value="Blue">Blue</option> 
                 <option value="LightBlue">Light Blue</option> 
                 <option value="SaturatedPurple">Saturated Purple</option> 

--- a/StreamDeckTradfri/Tradfri/TradfriHelper.cs
+++ b/StreamDeckTradfri/Tradfri/TradfriHelper.cs
@@ -91,28 +91,4 @@ namespace StreamDeckTradfri.Tradfri
             return res.IPAddress;
         }
     }
-
-	public static class TradfriColors
-	{
-		public const string Blue = "4a418a";
-		public const string LightBlue = "6c83ba";
-		public const string SaturatedPurple = "8f2686";
-		public const string Lime = "a9d62b";
-		public const string LightPurple = "c984bb";
-		public const string Yellow = "d6e44b";
-		public const string SaturatedPink = "d9337c";
-		public const string DarkPeach = "da5d41";
-		public const string SaturatedRed = "dc4b31";
-		public const string ColdSky = "dcf0f8";
-		public const string Pink = "e491af";
-		public const string Peach = "e57345";
-		public const string WarmAmber = "e78834";
-		public const string LightPink = "e8bedd";
-		public const string CoolDaylight = "eaf6fb";
-		public const string CandleLight = "ebb63e";
-		public const string WarmGlow = "efd275";
-		public const string WarmWhite = "f1e0b5";
-		public const string Sunrise = "f2eccf";
-		public const string CoolWhite = "f5faf6";
-	}
 }

--- a/StreamDeckTradfri/Tradfri/TradfriHelper.cs
+++ b/StreamDeckTradfri/Tradfri/TradfriHelper.cs
@@ -91,4 +91,28 @@ namespace StreamDeckTradfri.Tradfri
             return res.IPAddress;
         }
     }
+
+	public static class TradfriColors
+	{
+		public const string Blue = "4a418a";
+		public const string LightBlue = "6c83ba";
+		public const string SaturatedPurple = "8f2686";
+		public const string Lime = "a9d62b";
+		public const string LightPurple = "c984bb";
+		public const string Yellow = "d6e44b";
+		public const string SaturatedPink = "d9337c";
+		public const string DarkPeach = "da5d41";
+		public const string SaturatedRed = "dc4b31";
+		public const string ColdSky = "dcf0f8";
+		public const string Pink = "e491af";
+		public const string Peach = "e57345";
+		public const string WarmAmber = "e78834";
+		public const string LightPink = "e8bedd";
+		public const string CoolDaylight = "eaf6fb";
+		public const string CandleLight = "ebb63e";
+		public const string WarmGlow = "efd275";
+		public const string WarmWhite = "f1e0b5";
+		public const string Sunrise = "f2eccf";
+		public const string CoolWhite = "f5faf6";
+	}
 }


### PR DESCRIPTION
Adds support for assigning colors in set light actions
- Added a dictionary of supported colors for RGB Tradfri lights, including property inspector.
- The "none" option is included for use for turning lights off without transitioning to a new color.
- Tested using Stream Deck 5.0.1.14252

![image](https://user-images.githubusercontent.com/18252374/221806226-e6c8b237-6973-4ac2-9cc4-3e5ef99c77d9.png)
![image](https://user-images.githubusercontent.com/18252374/221806277-2d8c8b74-df18-4198-85f8-1a5028d73882.png)

Potential improvement:
- Add a radio button to change the list of available colors between the RBG set of colors and the Daylight-only set of colors.